### PR TITLE
Added SQLDriverFactory

### DIFF
--- a/src/main/java/org/javawebstack/orm/wrapper/SQLDriverFactory.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/SQLDriverFactory.java
@@ -1,0 +1,37 @@
+package org.javawebstack.orm.wrapper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class SQLDriverFactory {
+    private Map<String, Supplier<SQL>> suppliers = new HashMap<>();
+    private Map<String, String> properties;
+
+    public SQLDriverFactory(Map<String, String> properties) {
+        this.properties = properties;
+        addDefaultDrivers();
+    }
+
+    public void registerDriver (String name, Supplier<SQL> supplier) {
+        suppliers.put(name, supplier);
+    }
+
+    private void addDefaultDrivers() {
+        registerDriver("sqlite", () -> new SQLite(properties.get("file")));
+        registerDriver("mysql", () -> new MySQL(
+                properties.get("host"),
+                Integer.parseInt(properties.get("port")),
+                properties.get("name"),
+                properties.get("user"),
+                properties.get("password")
+        ));
+    }
+
+    public SQL getDriver(String name) throws SQLDriverNotFoundException {
+        Supplier<SQL> supplier = suppliers.get(name);
+        if (supplier == null)
+            throw new SQLDriverNotFoundException(name);
+        return supplier.get();
+    }
+}

--- a/src/main/java/org/javawebstack/orm/wrapper/SQLDriverNotFoundException.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/SQLDriverNotFoundException.java
@@ -1,0 +1,14 @@
+package org.javawebstack.orm.wrapper;
+
+public class SQLDriverNotFoundException extends Exception {
+    private String name;
+
+    public SQLDriverNotFoundException (String name) {
+        this.name = name;
+    }
+
+
+    public String getMessage() {
+        return "SQL Driver " + name + " not found!";
+    }
+}

--- a/src/test/java/org/javawebstack/orm/test/SQLDriverFactoryTest.java
+++ b/src/test/java/org/javawebstack/orm/test/SQLDriverFactoryTest.java
@@ -1,0 +1,30 @@
+package org.javawebstack.orm.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.javawebstack.orm.wrapper.SQLDriverFactory;
+import org.javawebstack.orm.wrapper.SQLDriverNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+class SQLDriverFactoryTest {
+    private SQLDriverFactory factory = new SQLDriverFactory(new HashMap<String, String>() {{
+        put("file", "sb.sqlite");
+        put("host", "localhost");
+        put("port", "3306");
+        put("name", "app");
+        put("user", "root");
+        put("password", "");
+    }});
+
+    @Test
+    public void testSQLite() throws SQLDriverNotFoundException {
+        assertNotNull(factory.getDriver("sqlite"));
+    }
+
+    @Test
+    public void testMySQL() throws SQLDriverNotFoundException {
+        assertNotNull(factory.getDriver("mysql"));
+    }
+}


### PR DESCRIPTION
The new SQLDriverFactory provides a more dynamic approach to construct sql implementations, with the ability to register custom implementations.
Usage: `new SQLDriverFactory(properties).getDriver("mysql");`
Tests are included.