### PR TITLE
Use is dirty before update

### DIFF
--- a/src/main/java/org/javawebstack/orm/Model.java
+++ b/src/main/java/org/javawebstack/orm/Model.java
@@ -73,6 +73,8 @@ public class Model {
 
     public boolean isDirty(String... fields) {
         List<String> dirty = getDirtyFields();
+        if(fields.length == 0 && dirty.size() > 0)
+            return true;
         for (String f : fields) {
             if (dirty.contains(f))
                 return true;

--- a/src/main/java/org/javawebstack/orm/ORMConfig.java
+++ b/src/main/java/org/javawebstack/orm/ORMConfig.java
@@ -16,6 +16,7 @@ public class ORMConfig {
     private boolean idAutoIncrement = true;
     private final List<TypeMapper> typeMappers = new ArrayList<>();
     private Injector injector;
+    private boolean preventUnnecessaryUpdates = true;
 
     public ORMConfig() {
         typeMappers.add(new DefaultMapper());
@@ -112,5 +113,14 @@ public class ORMConfig {
                 return mapper.getTypeParameters(type, size);
         }
         return null;
+    }
+
+    public boolean shouldPreventUnnecessaryUpdates() {
+        return preventUnnecessaryUpdates;
+    }
+
+    public ORMConfig setPreventUnnecessaryUpdates(boolean preventUnnecessaryUpdates) {
+        this.preventUnnecessaryUpdates = preventUnnecessaryUpdates;
+        return this;
     }
 }

--- a/src/main/java/org/javawebstack/orm/Repo.java
+++ b/src/main/java/org/javawebstack/orm/Repo.java
@@ -155,6 +155,8 @@ public class Repo<T extends Model> {
     }
 
     public void update(T entry) {
+        if(info.getConfig().shouldPreventUnnecessaryUpdates() && !entry.isDirty())
+            return;
         observers.forEach(o -> o.saving(entry));
         observers.forEach(o -> o.updating(entry));
         where(info.getIdField(), getId(entry)).update(entry);

--- a/src/main/java/org/javawebstack/orm/wrapper/QueryLogger.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/QueryLogger.java
@@ -1,0 +1,7 @@
+package org.javawebstack.orm.wrapper;
+
+public interface QueryLogger {
+
+    void log(String query, Object[] parameters);
+
+}

--- a/src/main/java/org/javawebstack/orm/wrapper/SQL.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/SQL.java
@@ -14,4 +14,8 @@ public interface SQL {
 
     void close(ResultSet resultSet);
 
+    void addQueryLogger(QueryLogger logger);
+
+    void removeQueryLogger(QueryLogger logger);
+
 }

--- a/src/test/java/org/javawebstack/orm/test/UpdateOnlyIfIsDirtyTest.java
+++ b/src/test/java/org/javawebstack/orm/test/UpdateOnlyIfIsDirtyTest.java
@@ -1,0 +1,53 @@
+package org.javawebstack.orm.test;
+
+import org.javawebstack.orm.ORM;
+import org.javawebstack.orm.ORMConfig;
+import org.javawebstack.orm.exception.ORMConfigurationException;
+import org.javawebstack.orm.test.shared.models.JustString;
+import org.javawebstack.orm.wrapper.QueryLogger;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UpdateOnlyIfIsDirtyTest extends ORMTestCase {
+
+    @Test
+    public void testOnlyUpdateIfIsDirty() throws ORMConfigurationException {
+        boolean[] updated = new boolean[1];
+        QueryLogger logger = (query, parameters) -> {
+            if(query.startsWith("UPDATE"))
+                updated[0] = true;
+        };
+        sql().addQueryLogger(logger);
+        ORM.register(JustString.class, sql(), new ORMConfig());
+        ORM.autoMigrate();
+        JustString model = new JustString();
+        model.setString("Test");
+        model.save();
+        model.save();
+        assertFalse(updated[0]);
+        model.setString("TestB");
+        model.save();
+        assertTrue(updated[0]);
+        sql().removeQueryLogger(logger);
+    }
+
+    @Test
+    public void testPreventUnnecessaryUpdatesOption() throws ORMConfigurationException {
+        boolean[] updated = new boolean[1];
+        QueryLogger logger = (query, parameters) -> {
+            if(query.startsWith("UPDATE"))
+                updated[0] = true;
+        };
+        sql().addQueryLogger(logger);
+        ORM.register(JustString.class, sql(), new ORMConfig().setPreventUnnecessaryUpdates(false));
+        ORM.autoMigrate();
+        JustString model = new JustString();
+        model.setString("Test");
+        model.save();
+        model.save();
+        assertTrue(updated[0]);
+        sql().removeQueryLogger(logger);
+    }
+
+}

--- a/src/test/java/org/javawebstack/orm/test/UpdateOnlyIfIsDirtyTest.java
+++ b/src/test/java/org/javawebstack/orm/test/UpdateOnlyIfIsDirtyTest.java
@@ -13,6 +13,7 @@ public class UpdateOnlyIfIsDirtyTest extends ORMTestCase {
 
     @Test
     public void testOnlyUpdateIfIsDirty() throws ORMConfigurationException {
+        // Using an array to make force mutability inside lamda expression
         boolean[] updated = new boolean[1];
         QueryLogger logger = (query, parameters) -> {
             if(query.startsWith("UPDATE"))

--- a/src/test/java/org/javawebstack/orm/test/shared/models/JustString.java
+++ b/src/test/java/org/javawebstack/orm/test/shared/models/JustString.java
@@ -4,10 +4,26 @@ import org.javawebstack.orm.Model;
 import org.javawebstack.orm.annotation.Column;
 
 public class JustString extends Model {
+
     @Column
     int id;
 
     @Column
     String string;
 
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    public void setString(String string) {
+        this.string = string;
+    }
 }


### PR DESCRIPTION
This branch implements an isDirty check before updates to prevent unnecessary updates. This behavior is enabled by default and can be disabled using an option in ORMConfig.

It also adds a QueryLogger mechanism that allows to record and inspect the raw sql queries. This makes the ugly debug logging unnecessary so i removed it.

Because i was in a call with @TimothyGillespie , i had to write tests :unamused: 