### PR TITLE
Fix Timestamp Bug

### DIFF
--- a/src/main/java/org/javawebstack/orm/mapper/DefaultMapper.java
+++ b/src/main/java/org/javawebstack/orm/mapper/DefaultMapper.java
@@ -51,8 +51,6 @@ public class DefaultMapper implements TypeMapper {
             return String.valueOf((char[]) source);
         if (type.equals(UUID.class))
             return source.toString();
-        if (type.equals(Timestamp.class))
-            return ((Timestamp) source).toString();
         if (type.equals(char.class))
             return String.valueOf((char) source);
 

--- a/src/test/java/org/javawebstack/orm/test/TypesTest.java
+++ b/src/test/java/org/javawebstack/orm/test/TypesTest.java
@@ -9,7 +9,6 @@ import org.javawebstack.orm.exception.ORMConfigurationException;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
-import java.time.Clock;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/org/javawebstack/orm/test/TypesTest.java
+++ b/src/test/java/org/javawebstack/orm/test/TypesTest.java
@@ -23,7 +23,7 @@ public class TypesTest extends ORMTestCase {
         ORM.register(ExampleModel.class, sql(), config);
         ORM.autoMigrate(true);
 
-        Timestamp timestamp = Timestamp.from(Instant.now(Clock.systemDefaultZone()));
+        Timestamp timestamp = Timestamp.from(Instant.now());
         ExampleModel model   = new ExampleModel();
         model.exampleString  = "Hello ;)";
         model.exampleEnum    = ExampleModel.Type.USER;

--- a/src/test/java/org/javawebstack/orm/test/TypesTest.java
+++ b/src/test/java/org/javawebstack/orm/test/TypesTest.java
@@ -9,6 +9,7 @@ import org.javawebstack.orm.exception.ORMConfigurationException;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,7 +23,7 @@ public class TypesTest extends ORMTestCase {
         ORM.register(ExampleModel.class, sql(), config);
         ORM.autoMigrate(true);
 
-        Timestamp timestamp = Timestamp.from(Instant.now());
+        Timestamp timestamp = Timestamp.from(Instant.now(Clock.systemDefaultZone()));
         ExampleModel model   = new ExampleModel();
         model.exampleString  = "Hello ;)";
         model.exampleEnum    = ExampleModel.Type.USER;
@@ -62,7 +63,7 @@ public class TypesTest extends ORMTestCase {
         assertEquals(model.exampleLongPrimitive, 999999999999999999L);
 
 
-        assertEquals(model.timestampTest.getTime() / 1000, timestamp.getTime() / 1000);
+        assertEquals(timestamp.getTime() / 1000, model.timestampTest.getTime() / 1000);
 
         assertEquals(model.exampleCharPrimitive, 'C');
 


### PR DESCRIPTION
This bug was caused by calling `.toString()` on timestamp when converting to sql. This apparently converts it to the local timezone and can be very critical bug.

It is fixed and verified now. I assume it did not show up in the CI because the timezone in the CI system timezone would be UTC.

Short version:
Timestamps were saved in the local time zone in MySQL databases. When retrieving them it assumed they were UTC.