### PR TITLE
Release 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <buildVersion>1.0.1-SNAPSHOT</buildVersion>
+        <buildVersion>1.0.2-SNAPSHOT</buildVersion>
     </properties>
 
     <groupId>org.javawebstack</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <buildVersion>1.0.3-SNAPSHOT</buildVersion>
+        <buildVersion>1.0.2-SNAPSHOT</buildVersion>
     </properties>
 
     <groupId>org.javawebstack</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.javawebstack</groupId>
             <artifactId>abstract-data</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.atteo</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.1</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,13 +83,13 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.24</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.27</version>
+            <version>8.0.28</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,18 @@
             <organization>JavaWebStack</organization>
             <organizationUrl>https://javawebstack.org</organizationUrl>
         </developer>
+        <developer>
+            <name>Timothy Gillespie</name>
+            <email>timothy@gillespie.eu</email>
+            <organization>JavaWebStack</organization>
+            <organizationUrl>https://javawebstack.org</organizationUrl>
+        </developer>
+        <developer>
+            <name>Julian Gojani</name>
+            <email>julian@gojani.xyz</email>
+            <organization>JavaWebStack</organization>
+            <organizationUrl>https://javawebstack.org</organizationUrl>
+        </developer>
     </developers>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,15 @@
         <dependency>
             <groupId>org.javawebstack</groupId>
             <artifactId>abstract-data</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.4</version>
         </dependency>
+        <!--- Temporary fix for transitive vulnerabilities -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.33</version>
+        </dependency>
+        <!--- ============================================ -->
         <dependency>
             <groupId>org.atteo</groupId>
             <artifactId>evo-inflector</artifactId>
@@ -71,7 +78,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -89,7 +96,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>8.0.30</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.javawebstack</groupId>
             <artifactId>abstract-data</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.atteo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <buildVersion>1.0.2-SNAPSHOT</buildVersion>
+        <buildVersion>1.0.3-SNAPSHOT</buildVersion>
     </properties>
 
     <groupId>org.javawebstack</groupId>

--- a/src/main/java/org/javawebstack/orm/Accessible.java
+++ b/src/main/java/org/javawebstack/orm/Accessible.java
@@ -1,7 +1,8 @@
 package org.javawebstack.orm;
 
 import org.javawebstack.orm.query.Query;
+import org.javawebstack.orm.query.QueryGroup;
 
 public interface Accessible {
-    <T extends Model> Query<T> access(Query<T> query, Object accessor);
+    <T extends Model> QueryGroup<T> access(Query<T> query, QueryGroup<T> accessChecks, Object accessor);
 }

--- a/src/main/java/org/javawebstack/orm/Repo.java
+++ b/src/main/java/org/javawebstack/orm/Repo.java
@@ -73,11 +73,11 @@ public class Repo<T extends Model> {
     }
 
     public Query<T> accessible(Object accessor) {
-        return accessible(query(), accessor);
+        return query().accessible(accessor);
     }
 
-    public Query<T> accessible(Query<T> query, Object accessor) {
-        return accessible == null ? query : accessible.access(query, accessor);
+    public Accessible getAccessible() {
+        return accessible;
     }
 
     public void save(T entry) {

--- a/src/main/java/org/javawebstack/orm/Repo.java
+++ b/src/main/java/org/javawebstack/orm/Repo.java
@@ -120,6 +120,7 @@ public class Repo<T extends Model> {
                     map.remove(idCol);
             }
             SQLQueryString qs = getConnection().builder().buildInsert(info, map);
+            SQL connection = Session.current() != null ? Session.current().getConnection() : this.connection;
             int id = connection.write(qs.getQuery(), qs.getParameters().toArray());
             if (info.isAutoIncrement())
                 info.getField(info.getIdField()).set(entry, id);

--- a/src/main/java/org/javawebstack/orm/Repo.java
+++ b/src/main/java/org/javawebstack/orm/Repo.java
@@ -17,8 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 public class Repo<T extends Model> {
 

--- a/src/main/java/org/javawebstack/orm/Session.java
+++ b/src/main/java/org/javawebstack/orm/Session.java
@@ -1,0 +1,46 @@
+package org.javawebstack.orm;
+
+import org.javawebstack.orm.wrapper.SQL;
+
+import java.util.function.Consumer;
+
+public class Session {
+
+    private static ThreadLocal<Session> sessions = new ThreadLocal<>();
+
+    public static Session current() {
+        return sessions.get();
+    }
+
+    private SQL connection;
+
+    private Session() {
+
+    }
+
+    public Session via(SQL connection) {
+        this.connection = connection;
+        return this;
+    }
+
+    public SQL getConnection() {
+        return connection;
+    }
+
+    public static void session(Consumer<Session> consumer) {
+        Session session = begin();
+        consumer.accept(session);
+        end();
+    }
+
+    public static Session begin() {
+        Session session = new Session();
+        sessions.set(session);
+        return session;
+    }
+
+    public static void end() {
+        sessions.remove();
+    }
+
+}

--- a/src/main/java/org/javawebstack/orm/TableInfo.java
+++ b/src/main/java/org/javawebstack/orm/TableInfo.java
@@ -6,7 +6,6 @@ import org.javawebstack.orm.exception.ORMConfigurationException;
 import org.javawebstack.orm.util.Helper;
 import org.javawebstack.orm.util.KeyType;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;

--- a/src/main/java/org/javawebstack/orm/TableInfo.java
+++ b/src/main/java/org/javawebstack/orm/TableInfo.java
@@ -57,8 +57,8 @@ public class TableInfo {
     }
 
     private void constructInfo (Class<? extends Model> model) throws ORMConfigurationException {
-        analyzeTable(model);
         analyzeColumns(model);
+        analyzeTable(model);
 
         if (!fields.containsKey(idField))
             idField = "uuid";

--- a/src/main/java/org/javawebstack/orm/TableInfo.java
+++ b/src/main/java/org/javawebstack/orm/TableInfo.java
@@ -42,14 +42,17 @@ public class TableInfo {
     public TableInfo(Class<? extends Model> model, ORMConfig config) throws ORMConfigurationException {
         this.config = config;
         this.modelClass = model;
-        if (model.getSuperclass() != Model.class) {
-            Class<? extends Model> superModel = (Class<? extends Model>) model.getSuperclass();
-            if (Modifier.isAbstract(superModel.getModifiers())) {
-                constructInfo(superModel);
+
+        Stack<Class<?>> superClasses = Helper.getSuperClassesTill(model, Model.class);
+        while (!superClasses.isEmpty()) {
+            Class<? extends Model> superClass = (Class<? extends Model>) superClasses.pop();
+            if (Modifier.isAbstract(superClass.getModifiers())) {
+                constructInfo(superClass);
             } else {
                 throw new ORMConfigurationException("The parent model has to be abstract!");
             }
         }
+
         constructInfo(model);
     }
 

--- a/src/main/java/org/javawebstack/orm/mapper/AbstractDataTypeMapper.java
+++ b/src/main/java/org/javawebstack/orm/mapper/AbstractDataTypeMapper.java
@@ -4,6 +4,15 @@ import org.javawebstack.abstractdata.AbstractElement;
 import org.javawebstack.orm.SQLType;
 
 public class AbstractDataTypeMapper implements TypeMapper {
+
+    private static final int BYTES_OVERHEAD_TEXT = 2;
+    private static final int BYTES_OVERHEAD_MEDIUMTEXT = 3;
+    private static final int BYTES_OVERHEAD_LONGTEXT = 4;
+
+    private static final long MAX_SIZE_TEXT = (long) Math.floor((65535 - BYTES_OVERHEAD_TEXT) / 4);
+    private static final long MAX_SIZE_MEDIUMTEXT = (long) Math.floor((16777215 - BYTES_OVERHEAD_MEDIUMTEXT) / 4);
+    private static final long MAX_SIZE_LONGTEXT = (long) Math.floor((4294967295L - BYTES_OVERHEAD_LONGTEXT) / 4);
+
     public Object mapToSQL(Object source, Class<?> type) {
         if (source == null)
             return null;
@@ -21,8 +30,13 @@ public class AbstractDataTypeMapper implements TypeMapper {
     }
 
     public SQLType getType(Class<?> type, int size) {
-        if (AbstractElement.class.isAssignableFrom(type))
+        if (AbstractElement.class.isAssignableFrom(type)) {
+            if (size > MAX_SIZE_MEDIUMTEXT)
+                return SQLType.LONGTEXT;
+            if (size > MAX_SIZE_TEXT)
+                return SQLType.MEDIUMTEXT;
             return SQLType.TEXT;
+        }
         return null;
     }
 

--- a/src/main/java/org/javawebstack/orm/mapper/DefaultMapper.java
+++ b/src/main/java/org/javawebstack/orm/mapper/DefaultMapper.java
@@ -109,7 +109,7 @@ public class DefaultMapper implements TypeMapper {
     }
 
     public SQLType getType(Class<?> type, int size) {
-        if (type.equals(String.class) || type.equals(char[].class))
+        if (type.equals(String.class) || type.equals(char[].class)) {
             // Upper limit of 4294967295 exceeds the int boundaries
             if (size > MAX_SIZE_MEDIUMTEXT)
                 return SQLType.LONGTEXT;
@@ -119,12 +119,18 @@ public class DefaultMapper implements TypeMapper {
                 return SQLType.VARCHAR;
             if (size == 1)
                 return SQLType.CHAR;
+        }
         if (type.equals(UUID.class))
             return SQLType.VARCHAR;
         if (type.equals(char.class))
             return SQLType.CHAR;
-        if (type.isEnum())
-            return SQLType.ENUM;
+        if (type.isEnum()) {
+            if(size < 1) {
+                return SQLType.ENUM;
+            } else {
+                return SQLType.VARCHAR;
+            }
+        }
         if (type.equals(boolean.class) || type.equals(Boolean.class) || type.equals(byte.class) || type.equals(Byte.class))
             return SQLType.TINYINT;
         if (type.equals(short.class) || type.equals(Short.class))
@@ -147,8 +153,13 @@ public class DefaultMapper implements TypeMapper {
     }
 
     public String getTypeParameters(Class<?> type, int size) {
-        if (type.isEnum())
-            return Arrays.stream(((Class<? extends Enum<?>>) type).getEnumConstants()).map(c -> "'" + c.name() + "'").collect(Collectors.joining(","));
+        if (type.isEnum()) {
+            if(size < 1) {
+                return Arrays.stream(((Class<? extends Enum<?>>) type).getEnumConstants()).map(c -> "'" + c.name() + "'").collect(Collectors.joining(","));
+            } else {
+                return String.valueOf(size);
+            }
+        }
         if (type.equals(String.class) || type.equals(char[].class))
             return size > MAX_SIZE_VARCHAR || size < 1 ? null : String.valueOf(size);
         if (type.equals(byte[].class))

--- a/src/main/java/org/javawebstack/orm/query/Query.java
+++ b/src/main/java/org/javawebstack/orm/query/Query.java
@@ -30,6 +30,8 @@ public class Query<T extends Model> {
     private boolean withDeleted = false;
     private final List<QueryColumn> groupBy = new ArrayList<>();
     private QueryGroup<T> having;
+    private boolean applyAccessible = false;
+    private Object accessor;
 
     public Query(Class<T> model) {
         this(Repo.get(model), model);
@@ -51,6 +53,14 @@ public class Query<T extends Model> {
 
     public boolean isWithDeleted() {
         return withDeleted;
+    }
+
+    public boolean shouldApplyAccessible() {
+        return applyAccessible;
+    }
+
+    public Object getAccessor() {
+        return accessor;
     }
 
     public QueryGroup<T> getWhereGroup() {
@@ -318,7 +328,9 @@ public class Query<T extends Model> {
     }
 
     public Query<T> accessible(Object accessor) {
-        return repo.accessible(this, accessor);
+        this.applyAccessible = true;
+        this.accessor = accessor;
+        return this;
     }
 
     public Query<T> filter(Map<String, String> filter) {

--- a/src/main/java/org/javawebstack/orm/query/Query.java
+++ b/src/main/java/org/javawebstack/orm/query/Query.java
@@ -144,18 +144,6 @@ public class Query<T extends Model> {
         return orWhere(left, "LIKE", right);
     }
 
-    public QueryGroup<T> whereMorph(String name, Class<? extends Model> type) {
-        return where.whereMorph(name, type);
-    }
-
-    public QueryGroup<T> whereMorph(String name, Class<? extends Model> type, Object id) {
-        return where.whereMorph(name, type, id);
-    }
-
-    public QueryGroup<T> whereMorph(String name, Model entity) {
-        return where.whereMorph(name, entity);
-    }
-
     public Query<T> orWhere(Class<? extends Model> leftTable, String left, String operator, Class<? extends Model> rightTable, String right) {
         if (rightTable != null)
             right = Repo.get(rightTable).getInfo().getTableName() + "." + Repo.get(rightTable).getInfo().getColumnName(right);
@@ -212,33 +200,25 @@ public class Query<T extends Model> {
         return orWhereId(operator, new QueryColumn(Repo.get(other).getInfo().getTableName() + "." + Repo.get(other).getInfo().getColumnName(field)));
     }
 
+    @Deprecated
     public Query<T> isNull(Object left) {
         where.isNull(left);
         return this;
     }
 
+    @Deprecated
     public Query<T> notNull(Object left) {
         where.notNull(left);
         return this;
     }
     
     public Query<T> whereNull(Object left) {
-        where.isNull(left);
+        where.whereNull(left);
         return this;
     }
     
     public Query<T> whereNotNull(Object left) {
-        where.notNull(left);
-        return this;
-    }
-
-    public Query<T> lessThan(Object left, Object right) {
-        where.lessThan(left, right);
-        return this;
-    }
-
-    public Query<T> greaterThan(Object left, Object right) {
-        where.greaterThan(left, right);
+        where.whereNotNull(left);
         return this;
     }
 
@@ -252,23 +232,25 @@ public class Query<T extends Model> {
         return this;
     }
 
+    @Deprecated
     public Query<T> orIsNull(Object left) {
         where.orIsNull(left);
         return this;
     }
 
+    @Deprecated
     public Query<T> orNotNull(Object left) {
         where.orNotNull(left);
         return this;
     }
 
-    public Query<T> orLessThan(Object left, Object right) {
-        where.orLessThan(left, right);
+    public Query<T> orWhereNull(Object left) {
+        where.orWhereNull(left);
         return this;
     }
 
-    public Query<T> orGreaterThan(Object left, Object right) {
-        where.orGreaterThan(left, right);
+    public Query<T> orWhereNotNull(Object left) {
+        where.orWhereNotNull(left);
         return this;
     }
 

--- a/src/main/java/org/javawebstack/orm/query/Query.java
+++ b/src/main/java/org/javawebstack/orm/query/Query.java
@@ -26,7 +26,7 @@ public class Query<T extends Model> {
     private final QueryGroup<T> where = new QueryGroup<>();
     private Integer offset;
     private Integer limit;
-    private List<QueryOrderBy> order = new ArrayList<>();
+    private final List<QueryOrderBy> order = new ArrayList<>();
     private boolean withDeleted = false;
     private final List<QueryColumn> groupBy = new ArrayList<>();
     private QueryGroup<T> having;
@@ -400,9 +400,13 @@ public class Query<T extends Model> {
         SQLQueryString qs = connection.builder().buildQuery(this);
         try {
             ResultSet rs = connection.read(qs.getQuery(), qs.getParameters().toArray());
-            SQLMapper.mapBack(repo, rs, entity);
-            connection.close(rs);
-            return entity;
+            if(rs.next()) {
+                SQLMapper.mapBack(repo, rs, entity);
+                connection.close(rs);
+                return entity;
+            } else {
+                return null;
+            }
         } catch (SQLException throwables) {
             throw new ORMQueryException(throwables);
         }

--- a/src/main/java/org/javawebstack/orm/query/QueryExists.java
+++ b/src/main/java/org/javawebstack/orm/query/QueryExists.java
@@ -1,8 +1,6 @@
 package org.javawebstack.orm.query;
 
 import org.javawebstack.orm.Model;
-import org.javawebstack.orm.TableInfo;
-import org.javawebstack.orm.wrapper.builder.SQLQueryString;
 
 public class QueryExists<T extends Model> implements QueryElement {
 

--- a/src/main/java/org/javawebstack/orm/query/QueryGroup.java
+++ b/src/main/java/org/javawebstack/orm/query/QueryGroup.java
@@ -29,16 +29,30 @@ public class QueryGroup<T extends Model> implements QueryElement {
         return queryElements;
     }
 
+    @Deprecated
     public QueryGroup<T> and(Function<QueryGroup<T>, QueryGroup<T>> group) {
+        return where(group);
+    }
+
+    public QueryGroup<T> where(Function<QueryGroup<T>, QueryGroup<T>> group) {
         QueryGroup<T> innerGroup = group.apply(new QueryGroup<>());
+        if(innerGroup.queryElements.size() == 0)
+            return this;
         if (queryElements.size() > 0)
             queryElements.add(QueryConjunction.AND);
         queryElements.add(innerGroup);
         return this;
     }
 
+    @Deprecated
     public QueryGroup<T> or(Function<QueryGroup<T>, QueryGroup<T>> group) {
+        return orWhere(group);
+    }
+
+    public QueryGroup<T> orWhere(Function<QueryGroup<T>, QueryGroup<T>> group) {
         QueryGroup<T> innerGroup = group.apply(new QueryGroup<>());
+        if(innerGroup.queryElements.size() == 0)
+            return this;
         if (queryElements.size() > 0)
             queryElements.add(QueryConjunction.OR);
         queryElements.add(innerGroup);
@@ -68,28 +82,18 @@ public class QueryGroup<T extends Model> implements QueryElement {
         return where(left, operator, right);
     }
 
-    public QueryGroup<T> whereMorph(String name, Class<? extends Model> type) {
-        return where(name + "Type", Repo.get(type).getInfo().getMorphType());
-    }
-
-    public QueryGroup<T> whereMorph(String name, Class<? extends Model> type, Object id) {
-        return whereMorph(name, type).where(name + "Id", id);
-    }
-
-    public QueryGroup<T> whereMorph(String name, Model entity) {
-        return whereMorph(name, entity.getClass(), Repo.get(entity.getClass()).getId(entity));
-    }
-
     public QueryGroup<T> where(Object left, Object right) {
         return where(left, "=", right);
     }
 
+    @Deprecated
     public QueryGroup<T> isNull(Object left) {
-        return where(left, "IS NULL", null);
+        return whereNull(left);
     }
 
+    @Deprecated
     public QueryGroup<T> notNull(Object left) {
-        return where(left, "IS NOT NULL", null);
+        return whereNotNull(left);
     }
     
     public QueryGroup<T> whereNull(Object left) {
@@ -98,14 +102,6 @@ public class QueryGroup<T extends Model> implements QueryElement {
     
     public QueryGroup<T> whereNotNull(Object left) {
         return where(left, "IS NOT NULL", null);
-    }
-
-    public QueryGroup<T> lessThan(Object left, Object right) {
-        return where(left, "<", right);
-    }
-
-    public QueryGroup<T> greaterThan(Object left, Object right) {
-        return where(left, ">", right);
     }
 
     public QueryGroup<T> orWhere(Object left, String condition, Object right) {
@@ -147,20 +143,22 @@ public class QueryGroup<T extends Model> implements QueryElement {
         return orWhereMorph(name, entity.getClass(), Repo.get(entity.getClass()).getId(entity));
     }
 
+    @Deprecated
     public QueryGroup<T> orIsNull(Object left) {
+        return orWhereNull(left);
+    }
+
+    @Deprecated
+    public QueryGroup<T> orNotNull(Object left) {
+        return orWhereNotNull(left);
+    }
+
+    public QueryGroup<T> orWhereNull(Object left) {
         return orWhere(left, "IS NULL", null);
     }
 
-    public QueryGroup<T> orNotNull(Object left) {
+    public QueryGroup<T> orWhereNotNull(Object left) {
         return orWhere(left, "IS NOT NULL", null);
-    }
-
-    public QueryGroup<T> orLessThan(Object left, Object right) {
-        return orWhere(left, "<", right);
-    }
-
-    public QueryGroup<T> orGreaterThan(Object left, Object right) {
-        return orWhere(left, ">", right);
     }
 
     public <M extends Model> QueryGroup<T> whereExists(Class<M> model, Function<Query<M>, Query<M>> consumer) {

--- a/src/main/java/org/javawebstack/orm/query/QueryGroup.java
+++ b/src/main/java/org/javawebstack/orm/query/QueryGroup.java
@@ -2,13 +2,10 @@ package org.javawebstack.orm.query;
 
 import org.javawebstack.orm.Model;
 import org.javawebstack.orm.Repo;
-import org.javawebstack.orm.TableInfo;
-import org.javawebstack.orm.wrapper.builder.SQLQueryString;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**

--- a/src/main/java/org/javawebstack/orm/query/QueryGroup.java
+++ b/src/main/java/org/javawebstack/orm/query/QueryGroup.java
@@ -3,6 +3,7 @@ package org.javawebstack.orm.query;
 import org.javawebstack.orm.Model;
 import org.javawebstack.orm.Repo;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -64,6 +65,11 @@ public class QueryGroup<T extends Model> implements QueryElement {
             return whereNull(left);
         if(condition.equalsIgnoreCase("!=") && right == null)
             return whereNotNull(left);
+        if((condition.equalsIgnoreCase("IN") || condition.equalsIgnoreCase("NOT IN")) && (right == null || Array.getLength(right) == 0)) {
+            left = 1;
+            condition = "=";
+            right = 2;
+        }
         if (queryElements.size() > 0)
             queryElements.add(QueryConjunction.AND);
         queryElements.add(new QueryCondition(left instanceof String ? new QueryColumn((String) left) : left, condition, right));
@@ -109,6 +115,11 @@ public class QueryGroup<T extends Model> implements QueryElement {
             return orIsNull(left);
         if(condition.equalsIgnoreCase("!=") && right == null)
             return orNotNull(left);
+        if((condition.equalsIgnoreCase("IN") || condition.equalsIgnoreCase("NOT IN")) && (right == null || Array.getLength(right) == 0)) {
+            left = 1;
+            condition = "=";
+            right = 2;
+        }
         if (queryElements.size() > 0)
             queryElements.add(QueryConjunction.OR);
         queryElements.add(new QueryCondition(left instanceof String ? new QueryColumn((String) left) : left, condition, right));

--- a/src/main/java/org/javawebstack/orm/util/Helper.java
+++ b/src/main/java/org/javawebstack/orm/util/Helper.java
@@ -1,5 +1,7 @@
 package org.javawebstack.orm.util;
 
+import java.util.Stack;
+
 public class Helper {
 
     public static String toSnakeCase(String source) {
@@ -41,4 +43,15 @@ public class Helper {
         return sb.toString();
     }
 
+    public static Stack<Class<?>> getSuperClassesTill(Class<?> clazz, Class<?> target) {
+        Stack<Class<?>> stack = new Stack<>();
+        Class<?> superClass = clazz.getSuperclass();
+
+        while (superClass != null && superClass != target) {
+            stack.push(superClass);
+            superClass = superClass.getSuperclass();
+        }
+
+        return stack;
+    }
 }

--- a/src/main/java/org/javawebstack/orm/wrapper/BaseSQL.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/BaseSQL.java
@@ -2,8 +2,8 @@ package org.javawebstack.orm.wrapper;
 
 import org.javawebstack.orm.exception.ORMQueryException;
 
-import java.sql.*;
 import java.sql.Date;
+import java.sql.*;
 import java.util.*;
 
 public abstract class BaseSQL implements SQL {

--- a/src/main/java/org/javawebstack/orm/wrapper/MySQL.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/MySQL.java
@@ -32,6 +32,10 @@ public class MySQL extends BaseSQL {
         this.timeout = timeout * 1000L;
     }
 
+    public SQL fork() {
+        return new MySQL(host, port, database, username, password, (int) (timeout / 1000L));
+    }
+
     public Connection getConnection() {
         long now = System.currentTimeMillis();
         if (now > lastQuery + timeout) {

--- a/src/main/java/org/javawebstack/orm/wrapper/SQL.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/SQL.java
@@ -22,4 +22,6 @@ public interface SQL {
 
     void removeQueryLogger(QueryLogger logger);
 
+    SQL fork();
+
 }

--- a/src/main/java/org/javawebstack/orm/wrapper/SQLite.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/SQLite.java
@@ -17,6 +17,10 @@ public class SQLite extends BaseSQL {
         this.file = file;
     }
 
+    public SQL fork() {
+        return new SQLite(file);
+    }
+
     public Connection getConnection() {
         try {
             if (c == null || c.isClosed()) {

--- a/src/main/java/org/javawebstack/orm/wrapper/builder/MySQLQueryStringBuilder.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/builder/MySQLQueryStringBuilder.java
@@ -7,7 +7,10 @@ import org.javawebstack.orm.query.*;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 

--- a/src/main/java/org/javawebstack/orm/wrapper/builder/MySQLQueryStringBuilder.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/builder/MySQLQueryStringBuilder.java
@@ -4,7 +4,6 @@ import org.javawebstack.orm.*;
 import org.javawebstack.orm.exception.ORMQueryException;
 import org.javawebstack.orm.query.*;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.Timestamp;

--- a/src/main/java/org/javawebstack/orm/wrapper/builder/MySQLQueryStringBuilder.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/builder/MySQLQueryStringBuilder.java
@@ -61,6 +61,13 @@ public class MySQLQueryStringBuilder implements QueryStringBuilder {
         QueryGroup<?> where = query.getWhereGroup();
         checkWithDeleted(repo, query.isWithDeleted(), where);
         if(query.shouldApplyAccessible()) {
+            if(where.getQueryElements().isEmpty()) {
+                try {
+                    where = (QueryGroup<Model>) accessibleAccessMethod.invoke(repo.getAccessible(), query, where, query.getAccessor());
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new ORMQueryException(e);
+                }
+            }
             QueryGroup<?> actualWhere = where;
             where = new QueryGroup<>()
                     .and(q -> (QueryGroup<Model>) actualWhere)
@@ -71,6 +78,7 @@ public class MySQLQueryStringBuilder implements QueryStringBuilder {
                             throw new ORMQueryException(e);
                         }
                     });
+
         }
         if (!where.getQueryElements().isEmpty()) {
             SQLQueryString qs = convertGroup(repo.getInfo(), where);

--- a/src/main/java/org/javawebstack/orm/wrapper/builder/QueryStringBuilder.java
+++ b/src/main/java/org/javawebstack/orm/wrapper/builder/QueryStringBuilder.java
@@ -1,7 +1,7 @@
 package org.javawebstack.orm.wrapper.builder;
 
 import org.javawebstack.orm.TableInfo;
-import org.javawebstack.orm.query.*;
+import org.javawebstack.orm.query.Query;
 
 import java.util.Map;
 

--- a/src/test/java/org/javawebstack/orm/test/DatesTest.java
+++ b/src/test/java/org/javawebstack/orm/test/DatesTest.java
@@ -10,9 +10,9 @@ import org.javawebstack.orm.annotation.SoftDelete;
 import org.javawebstack.orm.exception.ORMConfigurationException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.sql.Timestamp;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DatesTest extends ORMTestCase {
     @Test

--- a/src/test/java/org/javawebstack/orm/test/ExampleTest.java
+++ b/src/test/java/org/javawebstack/orm/test/ExampleTest.java
@@ -7,7 +7,9 @@ import org.javawebstack.orm.Repo;
 import org.javawebstack.orm.annotation.Column;
 import org.javawebstack.orm.exception.ORMConfigurationException;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ExampleTest extends ORMTestCase {
 

--- a/src/test/java/org/javawebstack/orm/test/SQLDriverFactoryTest.java
+++ b/src/test/java/org/javawebstack/orm/test/SQLDriverFactoryTest.java
@@ -1,7 +1,5 @@
 package org.javawebstack.orm.test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.javawebstack.orm.wrapper.MySQL;
 import org.javawebstack.orm.wrapper.SQLDriverFactory;
 import org.javawebstack.orm.wrapper.SQLDriverNotFoundException;
@@ -10,6 +8,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SQLDriverFactoryTest {
 

--- a/src/test/java/org/javawebstack/orm/test/TableInfoTest.java
+++ b/src/test/java/org/javawebstack/orm/test/TableInfoTest.java
@@ -38,6 +38,13 @@ public class TableInfoTest extends ORMTestCase {
         assertEquals(fetchedChild.content, child.content);
     }
 
+    @Test
+    public void testNonAbstractParent () throws ORMConfigurationException {
+        ORMConfig config = new ORMConfig()
+                .setDefaultSize(255);
+
+        assertThrows(ORMConfigurationException.class, () -> ORM.register(SecondChild.class, sql(), config), "The parent model has to be abstract!");
+    }
 
     public static abstract class Parent extends Model {
         @Column(ai = true, key = KeyType.PRIMARY)
@@ -45,6 +52,16 @@ public class TableInfoTest extends ORMTestCase {
     }
 
     public static class Child extends Parent {
+        @Column
+        public String content;
+    }
+
+    public static class NonAbstractParent extends Model {
+        @Column(ai = true, key = KeyType.PRIMARY)
+        public int id;
+    }
+
+    public static class SecondChild extends NonAbstractParent {
         @Column
         public String content;
     }

--- a/src/test/java/org/javawebstack/orm/test/TableInfoTest.java
+++ b/src/test/java/org/javawebstack/orm/test/TableInfoTest.java
@@ -1,0 +1,51 @@
+package org.javawebstack.orm.test;
+
+import org.javawebstack.orm.Model;
+import org.javawebstack.orm.ORM;
+import org.javawebstack.orm.ORMConfig;
+import org.javawebstack.orm.Repo;
+import org.javawebstack.orm.annotation.Column;
+import org.javawebstack.orm.exception.ORMConfigurationException;
+import org.javawebstack.orm.util.KeyType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TableInfoTest extends ORMTestCase {
+    @Test
+    public void testParentTableInfo () throws ORMConfigurationException {
+        ORMConfig config = new ORMConfig()
+                .setDefaultSize(255);
+        ORM.register(Child.class, sql(), config);
+
+        assertEquals(Repo.get(Child.class).getInfo().getFields().size(), 2);
+    }
+
+    @Test
+    public void testParentTableMigration () throws ORMConfigurationException {
+        ORMConfig config = new ORMConfig()
+                .setDefaultSize(255);
+        ORM.register(Child.class, sql(), config);
+        ORM.autoMigrate(true);
+
+        Child child = new Child();
+        child.id = 1337;
+        child.content = "Hello World!";
+        child.save();
+
+        Child fetchedChild = Repo.get(Child.class).get(1337);
+        assertEquals(fetchedChild.id, child.id);
+        assertEquals(fetchedChild.content, child.content);
+    }
+
+
+    public static abstract class Parent extends Model {
+        @Column(ai = true, key = KeyType.PRIMARY)
+        public int id;
+    }
+
+    public static class Child extends Parent {
+        @Column
+        public String content;
+    }
+}

--- a/src/test/java/org/javawebstack/orm/test/TableInfoTest.java
+++ b/src/test/java/org/javawebstack/orm/test/TableInfoTest.java
@@ -9,7 +9,8 @@ import org.javawebstack.orm.exception.ORMConfigurationException;
 import org.javawebstack.orm.util.KeyType;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TableInfoTest extends ORMTestCase {
     @Test

--- a/src/test/java/org/javawebstack/orm/test/UpdateOnlyIfIsDirtyTest.java
+++ b/src/test/java/org/javawebstack/orm/test/UpdateOnlyIfIsDirtyTest.java
@@ -7,7 +7,8 @@ import org.javawebstack.orm.test.shared.models.JustString;
 import org.javawebstack.orm.wrapper.QueryLogger;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UpdateOnlyIfIsDirtyTest extends ORMTestCase {
 

--- a/src/test/java/org/javawebstack/orm/test/other/QueryUtilTest.java
+++ b/src/test/java/org/javawebstack/orm/test/other/QueryUtilTest.java
@@ -6,7 +6,9 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.javawebstack.orm.test.shared.util.QueryStringUtil;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/org/javawebstack/orm/test/querybuilding/OrderByClauseTest.java
+++ b/src/test/java/org/javawebstack/orm/test/querybuilding/OrderByClauseTest.java
@@ -1,15 +1,19 @@
 package org.javawebstack.orm.test.querybuilding;
 
-import org.javawebstack.orm.exception.ORMQueryException;
 import org.javawebstack.orm.query.Query;
 import org.javawebstack.orm.test.exception.SectionIndexOutOfBoundException;
 import org.javawebstack.orm.test.shared.models.Datatype;
 import org.javawebstack.orm.test.shared.models.columnnames.OverwrittenColumnName;
 import org.javawebstack.orm.test.shared.verification.QueryVerification;
 import org.junit.jupiter.api.Test;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Random;
+
 import static org.javawebstack.orm.test.shared.setup.ModelSetup.setUpModel;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // This class tests the query generation for order by statements an MySQL
 class OrderByClauseTest {

--- a/src/test/java/org/javawebstack/orm/test/queryexecution/OrderByTest.java
+++ b/src/test/java/org/javawebstack/orm/test/queryexecution/OrderByTest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class OrderByTest extends ORMTestCase {
 


### PR DESCRIPTION
- Support for parent models
- Grouping the accessible to improve security
- Fixed Model.refresh()
- Implemented a via option in the Query to allow using a different connection for executing the query
- Implemented a session system that allows binding a different connection to a thread (this can be useful for using table locks)
- Added a fork method to the SQL interface to allow duplicating database connections
- Don't render empty groups anymore
- Render whereIn calls with null or empty arrays as `1=2`
- Replaced `isNull`, `isNotNull`, `orNull`, `orNotNull` with `whereNull`, `whereNotNull`, `orWhereNull`, `orWhereNotNull` (the old methods got deprecated and are subject to a removal in a future release)
- Removed `greaterThan`, `lessThan`, `orGreaterThan`, `orLessThan` and `whereMorph` because they were only helpers that  weren't used
- Updated abstract-data to 1.0.4